### PR TITLE
Fix Google AMP #237 (#243)

### DIFF
--- a/factory/template/sr_cnip.txt
+++ b/factory/template/sr_cnip.txt
@@ -4,6 +4,8 @@
 # 不包含广告过滤
 #
 
+DOMAIN-SUFFIX,ampproject.org,PROXY # Google AMP issue#237
+
 GEOIP,CN,DIRECT
 
 FINAL,proxy

--- a/factory/template/sr_cnip_ad.txt
+++ b/factory/template/sr_cnip_ad.txt
@@ -4,6 +4,8 @@
 # 包含广告过滤
 #
 
+DOMAIN-SUFFIX,ampproject.org,PROXY # Google AMP issue#237
+
 GEOIP,CN,DIRECT
 
 {{manual_reject}}


### PR DESCRIPTION
* fix: Google AMP CN CDN not work. fixed #237

* fix: Google AMP CN CDN not work. fixed h2y#237